### PR TITLE
David

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BUILD_DIR=debug/
 TARGET=ide
 
 default:
-	-rm $(TARGET).debug
+	-rm -f $(TARGET).debug
 	$(BUILD)$(TARGET).native
 	ln -s $(BUILD_DIR)$(SOURCE_DIR)$(TARGET).native $(TARGET).debug
 test : 

--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,5 @@ release:
 clean:
 	-rm -rf debug/
 	-rm -rf release/
-	-rm oUnit*
+	-rm -rf oUnit*
 	ocamlbuild -clean

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD=ocamlbuild \
 	  -I structure\
 	  -I tests\
 	  -build-dir "$(BUILD_DIR)" \
-	  -cflags "$(DEBUG_OPTION) -w +A@1..3@5@8..28@30..47@49..59" \
+	  -cflags "$(DEBUG_OPTION) -w +A@1..3@5@8..28@30..47-48@49..59" \
 	  -package lablgtk2 -package oUnit -package compiler-libs.common\
 	  $(SOURCE_DIR)
 

--- a/src/gui.ml
+++ b/src/gui.ml
@@ -8,8 +8,8 @@ let notimp_callback = (fun () -> prerr_endline "Not Implemented");;
 (* Pops up a "Do you want to quit" dialog and returns the answer *)
 let confirm_quit () =
     let dialog = GToolbox.question_box
-        "Confirm"
-        ["Yes";"No"]
+        ~title:"Confirm"
+        ~buttons:["Yes";"No"]
         "Do you really want to quit ?" in
     match dialog with
     | 0 | 2 -> false

--- a/src/tl_ast.mli
+++ b/src/tl_ast.mli
@@ -30,7 +30,7 @@ val file_to_ast : string ->  Parsetree.structure_item list
 (** Transform a string containing some ml code into a parsetree*)
 val string_to_ast : string -> Parsetree.structure_item list
 
-(** Prints a parstree *)
+(** Prints a parsetree *)
 val print_ast : Parsetree.structure_item list -> unit
 
 


### PR DESCRIPTION
Voici quelques modifications triviales après survol de votre code:

 * éviter des échecs inutiles liés à `rm` quand on utilise un peu `make` et `make clean`,
 * correction mineure du code pour éviter un warning lié aux labels,
 * désactivation du warning 48 lié aux labels optionnels,
 * correction de typos.

Bien sûr, vous n'êtes pas obligés d'incorporer ces modifications ou de les laisser tel quel!